### PR TITLE
[BUGFIX] Download composer only if not already exists

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@ command = "curl -s https://getcomposer.org/installer | php"
 unless node[:composer][:install_globally]
 	unless node[:composer][:install_dir].nil? || node[:composer][:install_dir].empty?
 		command = command + " -- --install-dir=#{node[:composer][:install_dir]}"
-    end
+	end
 end
 
 bash "download_composer" do
@@ -25,6 +25,7 @@ bash "download_composer" do
 	code <<-EOH
 		#{command}
 	EOH
+	not_if "which composer"
 end
 
 if node[:composer][:install_globally]
@@ -33,5 +34,6 @@ if node[:composer][:install_globally]
 		code <<-EOH
 			sudo mv composer.phar #{node[:composer][:prefix]}/bin/composer
 		EOH
+		not_if "which composer"
 	end
 end


### PR DESCRIPTION
If you create a VM with Vagrant and Chef and you use this composer recipe to install composer it works fine on the first vagrant up.

After the first provisioning you got the possibility to shutdown the vm via `vagrant halt`.
After this you will run the vm again with `vagrant up`.
Now chef only applies new changes.
But the composer installation runs again completly and throw an error.

Solution: Install composer only if not already there.

Log:

```
[2013-08-04T17:48:01+00:00] WARN: Chef::Exceptions::ShellCommandFailed is deprecated, use Mixlib::ShellOut::ShellCommandFailed
[2013-08-04T17:48:01+00:00] WARN: Called from:
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear_channel.rb:89:in `exists?'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear_channel.rb:50:in `class_from_file'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-11.2.0/bin/../lib/chef/provider/lwrp_base.rb:138:in `instance_eval'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-11.2.0/bin/../lib/chef/provider/lwrp_base.rb:138:in `action_update'

[2013-08-04T17:48:01+00:00] WARN: Chef::Exceptions::ShellCommandFailed is deprecated, use Mixlib::ShellOut::ShellCommandFailed
[2013-08-04T17:48:01+00:00] WARN: Called from:
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear_channel.rb:89:in `exists?'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/php/providers/pear_channel.rb:50:in `class_from_file'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-11.2.0/bin/../lib/chef/provider/lwrp_base.rb:138:in `instance_eval'
  /opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-11.2.0/bin/../lib/chef/provider/lwrp_base.rb:138:in `action_update'


================================================================================
Error executing action `run` on resource 'bash[download_composer]'
================================================================================


Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '255'
---- Begin output of "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" ----
STDOUT: 
STDERR: 
---- End output of "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" ----
Ran "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" returned 255


Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/composer/recipes/default.rb

 23: bash "download_composer" do
 24:    cwd "#{Chef::Config[:file_cache_path]}"
 25:    code <<-EOH
 26:        #{command}
 27:    EOH
 28: end
 29: 



Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/composer/recipes/default.rb:23:in `from_file'

bash("download_composer") do
  cookbook_name :composer
  code "\t\tcurl -s https://getcomposer.org/installer | php\n"
  action "run"
  recipe_name "default"
  retry_delay 2
  returns 0
  backup 5
  cwd "/var/chef/cache"
  retries 0
  interpreter "bash"
  command "\"bash\"  \"/tmp/chef-script20130804-1838-1m50sps-0\""
end



[2013-08-04T17:48:03+00:00] INFO: Running queued delayed notifications before re-raising exception
[2013-08-04T17:48:03+00:00] ERROR: Running exception handlers
[2013-08-04T17:48:03+00:00] ERROR: Exception handlers complete
[2013-08-04T17:48:03+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-08-04T17:48:03+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: bash[download_composer] (composer::default line 23) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '255'
---- Begin output of "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" ----
STDOUT: 
STDERR: 
---- End output of "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" ----
Ran "bash"  "/tmp/chef-script20130804-1838-1m50sps-0" returned 255
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
