### PR TITLE
remove include_recipe php

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "dev@escapestudios.com"
 license          "MIT"
 description      "Installs/Configures Composer"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.5"
+version          "0.0.6"
 
 %w{ debian ubuntu redhat centos fedora scientific amazon }.each do |os|
 supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,8 +5,6 @@
 # Copyright 2012-2013, Escape Studios
 #
 
-include_recipe "php"
-
 #install/upgrade curl
 package "curl" do
 	action :upgrade


### PR DESCRIPTION
no needs for incude_recipe "php", this just remove settings of php and install packages such as php5-cgi and other if I use different cookbook for setup php
