### PR TITLE
Make chmod configurable for remote file download

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ else
     default['composer']['url'] = "http://getcomposer.org/composer.phar"
     default['composer']['install_dir'] = "/usr/local/bin"
     default['composer']['install_globally'] = true
+    default['composer']['chmod'] = "0755"
     default['composer']['bin'] = "#{node['composer']['install_dir']}/composer"
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -30,7 +30,7 @@ else
 
     remote_file cache_file do
         source node['composer']['url']
-        mode "0755"
+        mode node['composer']['chmod']
         action :create
         not_if do
             ::File.exists?(cache_file)


### PR DESCRIPTION
If composer.phar will be downloaded the file got a hard chmod 0755.
This means only the user and the group can execute composer.
A listing on my vagrant machine:

```
vagrant@precise64:~$ cd /var/chef/cache/composer/
vagrant@precise64:/var/chef/cache/composer$ ls -al
total 952
drwxr-xr-x  2 root    root   4096 Feb  6 12:34 .
drwxr-xr-x 16 vagrant root   4096 Feb  6 12:34 ..
-rwxrwxr--  1 root    root 963742 Feb  6 12:34 composer.phar
```

If i get ssh access to my vagrant via `vagrant ssh` i am logged in with the vagrant user.
The vagrant user got no permission to execute composer:

```
vagrant@precise64:~$ /usr/local/bin/composer
-bash: /usr/local/bin/composer: Permission denied
```

This PR makes the chmod configurable. No breaking change.
What do you think about this?
