### PR TITLE
Fix composer_project resource's :dev and :quiet attributes (fixes #11)

### DIFF
--- a/resources/project.rb
+++ b/resources/project.rb
@@ -9,8 +9,8 @@ actions :install, :update, :dump_autoload
 default_action :install
 
 attribute :project_dir, :kind_of => String, :name_attribute => true
-attribute :dev, :equal_to => [TrueClass, FalseClass], :default => false
-attribute :quiet, :equal_to => [TrueClass, FalseClass], :default => true
+attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 
 def initialize(*args)
     super


### PR DESCRIPTION
Replaced `:equal_to` by `:kind_of` in `composer_project` resource.

This fixes also issue #11.
