### PR TITLE
Make sure COMPOSER_HOME is set on each invocation (when running chef as ...

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -35,6 +35,7 @@ def make_execute(cmd)
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist}"
+    environment 'COMPOSER_HOME' => node['composer']['install_dir']
     action :run
     only_if 'which composer'
     user new_resource.user

--- a/recipes/global_configs.rb
+++ b/recipes/global_configs.rb
@@ -23,6 +23,7 @@ unless configs.nil?
         value.each_pair do |value_k, value_v|
           execute "composer-config-for-#{user}" do
             command "composer config --global #{option}.#{value_k} #{value_v}"
+            environment 'COMPOSER_HOME' => node['composer']['install_dir']
             user user
             group user
             action :run
@@ -31,6 +32,7 @@ unless configs.nil?
       else
         execute "composer-config-for-#{user}" do
           command "composer config --global #{option} #{value}"
+          environment 'COMPOSER_HOME' => node['composer']['install_dir']
           user user
           group user
           action :run


### PR DESCRIPTION
Per seburban's comments in https://github.com/escapestudios-cookbooks/composer/issues/20, I've added the COMPOSER_HOME environment variable in three places where composer is being executed. This fixes the same issue I experienced using composer_project in 1.0.3. I haven't specifically tested the other two invocations.
