### PR TITLE
Create a hard link to the composer phar

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -51,5 +51,6 @@ else
   link file do
     to cache_file
     action :create
+    link_type :hard
   end
 end


### PR DESCRIPTION
This means that when the cache is in a non globally readable location the composer command will work
Fixes #25
