### PR TITLE
Use --optimize-autoloader on composer install

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -29,10 +29,8 @@ end
 def make_execute(cmd)
   dev = new_resource.dev ? '--dev' : '--no-dev'
   quiet = new_resource.quiet ? '--quiet' : ''
-  optimize = new_resource.optimize_autoloader ? '--optimize' : ''
+  optimize = new_resource.optimize_autoloader ? optimize_flag(cmd) : ''
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
-
-  optimize = cmd == 'install' && optimize.length > 0 ? optimize + '-autoloader' : optimize
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
@@ -44,4 +42,8 @@ def make_execute(cmd)
     group new_resource.group
     umask new_resource.umask
   end
+end
+
+def optimize_flag(cmd)
+  return %(install update).include? cmd ? '--optimize-autoloader' : '--optimize'
 end


### PR DESCRIPTION
Setting `optimize true` on the `:install` action results to an error in Composer because the proper way of optimizing the autoloader during installs is with the `--optimize-autoloader` flag.
