### PR TITLE
Fix for ShellCommandFailed with optimize_autoload

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -45,5 +45,5 @@ def make_execute(cmd)
 end
 
 def optimize_flag(cmd)
-  %(install update).include? cmd ? '--optimize-autoloader' : '--optimize'
+  (%(install update).include? cmd) ? '--optimize-autoloader' : '--optimize'
 end


### PR DESCRIPTION
Using optimize_autoload causes the composer command to always be generated with "false" as the last argument, due to an operator precedence issue.

The bug occurs on Ruby 1.9.3p484 at the least, may not occur on some others, but the fix should be harmless on them.
