### PR TITLE
Fix/cache dir

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,27 +1,31 @@
 ---
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+driver:
+  name: vagrant
+  driver_config:
+    require_chef_omnibus: latest
+
+provisioner:
+  name: chef_zero
+  solo_rb:
+    ssl_verify_mode: verify_peer
 
 platforms:
-#  - name: ubuntu-12.04
-#    driver_config:
-#        box: opscode-ubuntu-12.04
-#        box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-  - name: ubuntu-13.04
+  - name: ubuntu-14.04
     driver_config:
-      box: opscode-ubuntu-13.04
-      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-13.04_provisionerless.box
-#  - name: centos-6.3
-#    driver_config:
-#        box: opscode-centos-6.3
-#        box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-6.3_provisionerless.box
-  - name: centos-6.4
+        box: opscode-ubuntu-14.04
+        box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+
+  - name: centos-7.0
     driver_config:
-        box: opscode-centos-6.4
-        box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+        box: opscode-centos-7.0
+        box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
 
 suites:
   - name: default
     run_list:
       - recipe[composer::default]
+    attributes: {
+      "composer": {
+        "install_globally": true
+      }
+    }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ UselessAssignment:
 
 MethodLength:
   Enabled: false
+
+AbcSize:
+  Enabled: false
+  

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ group :unit do
 end
 
 group :integration do
-  gem 'test-kitchen', '~> 1.2'
-  gem 'kitchen-vagrant', '~> 0.11'
-  gem 'serverspec', '~> 1.0'
+  gem 'chef'
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'serverspec', '~> 2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,7 @@ group :unit, :integration do
 end
 
 group :unit do
-  gem 'chefspec', '~> 3.1'
-  gem 'rspec-expectations', '~> 2.14.0'
+  gem 'chefspec'
 end
 
 group :integration do

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,32 +25,12 @@ else
     not_if "php -m | grep 'Phar'"
   end
 
-  cache_dir = "#{Chef::Config[:file_cache_path]}/composer"
+  file = node['composer']['install_globally'] ? "#{node['composer']['install_dir']}/composer" : "#{node['composer']['install_dir']}/composer.phar"
 
-  directory cache_dir do
-    action :create
-  end
-
-  cache_file = "#{cache_dir}/composer.phar"
-
-  remote_file cache_file do
+  remote_file file do
     source node['composer']['url']
     mode node['composer']['mask']
     action :create
-    not_if do
-      ::File.exist?(cache_file)
-    end
-  end
-
-  if node['composer']['install_globally']
-    file = "#{node['composer']['install_dir']}/composer"
-  else
-    file = "#{node['composer']['install_dir']}/composer.phar"
-  end
-
-  link file do
-    to cache_file
-    link_type node['composer']['link_type']
-    action :create
+    not_if { ::File.exist?(file) }
   end
 end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -5,7 +5,7 @@ describe 'composer::default' do
     stub_command("php -m | grep 'Phar'").and_return(true)
   end
 
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'includes the install recipe' do
     expect(chef_run).to include_recipe('composer::install')

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -7,7 +7,7 @@ describe package('php5') do
 end
 
 describe command("php -m | grep 'Phar'") do
-  its(:stdout) { should match /Phar/ }
+  its(:stdout) { should match 'Phar' }
 end
 
 describe file('/usr/local/bin/composer') do

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -1,0 +1,16 @@
+require 'serverspec'
+set :backend, :exec
+set :path, '/sbin:/usr/sbin:/usr/local/sbin:$PATH'
+
+describe package('php5') do
+  it { should be_installed }
+end
+
+describe command("php -m | grep 'Phar'") do
+  its(:stdout) { should match /Phar/ }
+end
+
+describe file('/usr/local/bin/composer') do
+  it { should be_file }
+  it { should be_mode 755 }
+end


### PR DESCRIPTION
This PR fixes #36 (which is a big show-stopper to rely on temporary cache dirs)
Note that vagrant dropped support for some temp/cache folders in 1.7.2
It also fixes travis-ci, upgrades test-kitchen and chefspec to current versions/boxes and uses serverspec2 for integration testing.