### PR TITLE
Add git_ssh_wrapper support to the project resource

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -31,11 +31,13 @@ def make_execute(cmd)
   quiet = new_resource.quiet ? '--quiet' : ''
   optimize = new_resource.optimize_autoloader ? optimize_flag(cmd) : ''
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
+  env = { 'COMPOSER_HOME' => Composer.home_dir(node) }
+  env['GIT_SSH'] = new_resource.git_ssh_wrapper if new_resource.git_ssh_wrapper
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
     command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist}"
-    environment 'COMPOSER_HOME' => Composer.home_dir(node)
+    environment env
     action :run
     only_if 'which composer'
     user new_resource.user

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -16,6 +16,7 @@ attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :user, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
 attribute :umask, :kind_of => [String, Fixnum], :default => 0002
+attribute :git_ssh_wrapper, :kind_of => String, :default => nil
 
 def initialize(*args)
   super


### PR DESCRIPTION
I needed to use the GIT_SSH environment variable so I added support for it to the project resources in a similar manner to the chef deploy resource.