### PR TITLE
Added --prefer-source

### DIFF
--- a/providers/project.rb
+++ b/providers/project.rb
@@ -31,10 +31,11 @@ def make_execute(cmd)
   quiet = new_resource.quiet ? '--quiet' : ''
   optimize = new_resource.optimize_autoloader ? optimize_flag(cmd) : ''
   prefer_dist = new_resource.prefer_dist ? '--prefer-dist' : ''
+  prefer_source = new_resource.prefer_source ? '--prefer-source' : ''
 
   execute "#{cmd}-composer-for-project" do
     cwd new_resource.project_dir
-    command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist}"
+    command "#{node['composer']['bin']} #{cmd} --no-interaction --no-ansi #{quiet} #{dev} #{optimize} #{prefer_dist} #{prefer_source}"
     environment 'COMPOSER_HOME' => Composer.home_dir(node)
     action :run
     only_if 'which composer'

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -13,6 +13,7 @@ attribute :dev, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :quiet, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :optimize_autoloader, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :prefer_dist, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :prefer_source, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :user, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
 attribute :umask, :kind_of => [String, Fixnum], :default => 0002


### PR DESCRIPTION
Hi,
The library support `--prefer-dist` which is set to false by default, but it seems it's enabled by default in composer.


> --prefer-source: There are two ways of downloading a package: source and dist. For stable versions composer will use the dist by default. The source is a version control repository. If --prefer-source is enabled, composer will install from source if there is one. This is useful if you want to make a bugfix to a project and get a local git clone of the dependency directly.


Adding `--prefer-source` will allow to force sources. It's particularly useful when you reach this kind of rate limit issue on github about rate limit : https://github.com/composer/composer/issues/1861