### PR TITLE
Remove php cookbook dependency

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,7 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[php::default]
       - recipe[composer::default]
     attributes: {
       "composer": {

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,7 @@
 source 'https://supermarket.chef.io'
 
+group :integration do
+  cookbook 'php'
+end
+
 metadata

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Requirements
 
 ## Cookbooks:
 
+This cookbook has no external dependencies, but recommends the following cookbooks:
+
 * php
-
-This cookbook recommends the following cookbooks:
-
 * windows
 
 ### Depending on your environment, these recommended cookbooks are actual dependencies (depends):
-* Using the community PHP cookbook to get PHP installed? You'll need the php cookbook to be available.
+* Using the community PHP cookbook to install PHP? You'll need the php cookbook to be
+available and its recipe included earlier in your run list (e.g. `recipe[php::default]`).
 * Running on Windows? You'll need the windows cookbook to be available.
 
 ## Platforms:
@@ -43,7 +43,6 @@ Attributes
 * `node['composer']['link_type']` - link type for composer.phar link - default :symbolic
 * `node['composer']['global_configs']` - Hash with global config options for users, eg. { "userX" => { "github-oauth" => { "github.com" => "userX_oauth_token" }, "vendor-dir" => "myvendordir" } } - default {}
 * `node['composer']['home_dir']` - COMPOSER_HOME, defaults to nil (in which case install_dir will be used), please do read the [Composer documentation on COMPOSER_HOME](https://getcomposer.org/doc/03-cli.md#composer-home) when setting a custom home_dir
-* `node['composer']['php_recipe']` - The php recipe to include, defaults to "php::default"
 
 Resources / Providers
 =====================
@@ -80,7 +79,7 @@ composer_project "/path/to/project" do
     dev false
     quiet true
     prefer_dist false
-    action :require 
+    action :require
 end
 
 #update project vendors

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Requirements
 
 ## Cookbooks:
 
-This cookbook has no external dependencies, but recommends the following cookbooks:
+This cookbook has no external dependencies, but suggests the following cookbooks:
 
 * php
 * windows
 
-### Depending on your environment, these recommended cookbooks are actual dependencies (depends):
+### Depending on your environment, these suggested cookbooks are actual dependencies (depends):
 * Using the community PHP cookbook to install PHP? You'll need the php cookbook to be
 available and its recipe included earlier in your run list (e.g. `recipe[php::default]`).
 * Running on Windows? You'll need the windows cookbook to be available.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,8 +5,6 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-include_attribute 'php'
-
 if node['platform'] == 'windows'
   default['composer']['url'] = 'https://getcomposer.org/Composer-Setup.exe'
   default['composer']['install_dir'] = 'C:\\ProgramData\\ComposerSetup'
@@ -22,4 +20,3 @@ end
 
 default['composer']['global_configs'] = {}
 default['composer']['home_dir'] = nil
-default['composer']['php_recipe'] = 'php::default'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,9 +10,6 @@ version '2.2.1'
   supports os
 end
 
-suggests 'php'
-suggests 'windows'
-
 recipe 'composer', 'Installs (if applicable) and self-updates composer.'
 recipe 'composer::install', 'Installs composer.'
 recipe 'composer::self_update', 'Installs (if applicable) and self-updates composer.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,8 +10,8 @@ version '2.2.0'
   supports os
 end
 
-recommends 'php'
-recommends 'windows'
+suggests 'php'
+suggests 'windows'
 
 recipe 'composer', 'Installs (if applicable) and self-updates composer.'
 recipe 'composer::install', 'Installs composer.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,8 +10,7 @@ version '2.2.0'
   supports os
 end
 
-depends 'php'
-
+recommends 'php'
 recommends 'windows'
 
 recipe 'composer', 'Installs (if applicable) and self-updates composer.'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -5,8 +5,6 @@
 # Copyright 2012-2014, Escape Studios
 #
 
-include_recipe node['composer']['php_recipe']
-
 if node['platform'] == 'windows'
   windows_package 'Composer - PHP Dependency Manager' do
     source node['composer']['url']

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -2,8 +2,8 @@ require 'serverspec'
 set :backend, :exec
 set :path, '/sbin:/usr/sbin:/usr/local/sbin:$PATH'
 
-describe package('php5') do
-  it { should be_installed }
+describe command('php -v') do
+  its(:stdout) { should match('PHP 5.') }
 end
 
 describe command("php -m | grep 'Phar'") do


### PR DESCRIPTION
This cookbook doesn't specifically depend on the php cookbook, only on PHP itself. This PR removes the dependency while preserving integration tests, etc.

I'm also suggesting removal of the `['composer']['php_recipe']` node attribute and the related `include_recipe` to install PHP. Anything related to PHP installation seems out-of-scope for this cookbook.  It's just as simple for someone to include `recipe[php::default]` earlier in their run list (and seems more "Chef-ish").  Plus it solves the issue of those who don't have a PHP recipe to point to (e.g. if they're using a custom AWS AMI with PHP pre-installed).
